### PR TITLE
2 add code for invariant mass

### DIFF
--- a/analysis/basic-analysis/event-analysis.cxx
+++ b/analysis/basic-analysis/event-analysis.cxx
@@ -34,6 +34,7 @@
 #include "TLorentzVector.h"
 #include "TVector3.h"
 
+using namespace std;
 
 MyxAODAnalysis :: MyxAODAnalysis (const std::string& name,
                                   ISvcLocator *pSvcLocator)
@@ -93,7 +94,7 @@ StatusCode MyxAODAnalysis :: initialize ()
     ANA_CHECK (book (TH1D("h_phi_Zd2", "h_phi_Zd2", 100, -4.5, 4.5)));
     ANA_CHECK (book (TH1D("h_phi_Zd3", "h_phi_Zd3", 100, -4.5, 4.5)));
     ANA_CHECK (book (TH1D("h_phi_Zd4", "h_phi_Zd4", 100, -4.5, 4.5)));
-    //Visible leptons (l/e/u)
+    //Visible leptons (e; u;)
     ANA_CHECK (book (TH1D("h_pT_e1", "h_pT_e1", 100, 0, 500))); ANA_CHECK (book (TH1D("h_pT_u1", "h_pT_u1", 100, 0, 500)));
     ANA_CHECK (book (TH1D("h_pT_e2", "h_pT_e2", 100, 0, 500))); ANA_CHECK (book (TH1D("h_pT_u2", "h_pT_u2", 100, 0, 500)));
     ANA_CHECK (book (TH1D("h_pT_e3", "h_pT_e3", 100, 0, 500))); ANA_CHECK (book (TH1D("h_pT_u3", "h_pT_u3", 100, 0, 500)));
@@ -106,14 +107,27 @@ StatusCode MyxAODAnalysis :: initialize ()
     ANA_CHECK (book (TH1D("h_phi_e2","h_phi_e2", 100, -4.5, 4.5))); ANA_CHECK (book (TH1D("h_phi_u2","h_phi_u2", 100, -4.5, 4.5)));
     ANA_CHECK (book (TH1D("h_phi_e3","h_phi_e3", 100, -4.5, 4.5))); ANA_CHECK (book (TH1D("h_phi_u3","h_phi_u3", 100, -4.5, 4.5)));
     ANA_CHECK (book (TH1D("h_phi_e4","h_phi_e4", 100, -4.5, 4.5))); ANA_CHECK (book (TH1D("h_phi_u4","h_phi_u4", 100, -4.5, 4.5)));
+    //Multileptons
+    ANA_CHECK (book (TH1D("h_pT_lead", "h_pT_lead", 100, 0, 500)));
+    ANA_CHECK (book (TH1D("h_pT_sublead", "h_pT_sublead", 100, 0, 500)));
     //MET
     ANA_CHECK (book (TH1F("h_missingET","h_missingET",100,0,1000)));
     ANA_CHECK (book (TH1D("h_missingET_NonInt","h_missingET_NonInt",100,0,1000)));
 
+    //Testing
+    // ANA_CHECK (book (TH1D("h_M_S1", "h_M_S1", 100, 0, 200)));
+    // ANA_CHECK (book (TH1D("h_M_Zd1", "h_M_Zd1", 100, 0, 200)));
+    // ANA_CHECK (book (TH1D("h_invMass_l1l2", "h_invMass_l1l2", 100, 0, 200)));
+    // ANA_CHECK (book (TH1D("h_invMass_l3l4", "h_invMass_l3l4", 100, 0, 200)));
+    // ANA_CHECK (book (TH1D("h_invMass_4l", "h_invMass_4l", 100, 0, 200)));
+    // ANA_CHECK (book (TH1D("h_vectorInvMass_l1l2", "h_vectorInvMass_l1l2", 100, 0, 200)));
+    // ANA_CHECK (book (TH1D("h_vectorInvMass_l3l4", "h_vectorInvMass_l3l4", 100, 0, 200)));
+    // ANA_CHECK (book (TH1D("h_vectorInvMass_4l", "h_vectorInvMass_4l", 100, 0, 200)));
+
     return StatusCode::SUCCESS;
 }
 
-// Initialize counting variables
+/* counting variables */
 float l_multiplicity = 0;
 float l_multiplicity_44 = 0;
 float l_multiplicity_3 = 0;
@@ -125,12 +139,46 @@ int n_S = 0;
 int n_Zd = 0;
 int n_childl1, n_childl2, n_childl3, n_childl4, n_childl5, n_childl6, n_childl7, n_childl8 = 0;
 
-// Initialize Kinematic variables //
-double m_H, pT_H, eta_H, phi_H;
-double m_S1, m_S2, pT_S1, pT_S2, eta_S1, eta_S2, phi_S1, phi_S2;
-double m_Zd1, m_Zd2, m_Zd3, m_Zd4, pT_Zd1, pT_Zd2, pT_Zd3, pT_Zd4, eta_Zd1, eta_Zd2, eta_Zd3, eta_Zd4, phi_Zd1, phi_Zd2, phi_Zd3, phi_Zd4;
-double pT_e1, pT_e2, pT_e3, pT_e4, eta_e1, eta_e2, eta_e3, eta_e4, phi_e1, phi_e2, phi_e3, phi_e4;
-double pT_u1, pT_u2, pT_u3, pT_u4, eta_u1, eta_u2, eta_u3, eta_u4, phi_u1, phi_u2, phi_u3, phi_u4;
+/* Kinematic variables */
+double m_H, pT_H, eta_H, phi_H; //H
+double m_S1, m_S2, pT_S1, pT_S2, eta_S1, eta_S2, phi_S1, phi_S2; //S
+double m_Zd1, m_Zd2, m_Zd3, m_Zd4, pT_Zd1, pT_Zd2, pT_Zd3, pT_Zd4, eta_Zd1, eta_Zd2, eta_Zd3, eta_Zd4, phi_Zd1, phi_Zd2, phi_Zd3, phi_Zd4; //Zd
+double pT_e1, pT_e2, pT_e3, pT_e4, eta_e1, eta_e2, eta_e3, eta_e4, phi_e1, phi_e2, phi_e3, phi_e4; //electron pT, eta, phi
+double pT_u1, pT_u2, pT_u3, pT_u4, eta_u1, eta_u2, eta_u3, eta_u4, phi_u1, phi_u2, phi_u3, phi_u4; //muon pT, eta, phi
+double e_e1, e_e2, e_e3, e_e4, px_e1, px_e2, px_e3, px_e4, py_e1, py_e2, py_e3, py_e4, pz_e1, pz_e2, pz_e3, pz_e4; //electron e, px, py, pz
+double e_u1, e_u2, e_u3, e_u4, px_u1, px_u2, px_u3, px_u4, py_u1, py_u2, py_u3, py_u4, pz_u1, pz_u2, pz_u3, pz_u4; //muon e, px, py, pz
+double pT_l1l2, pT_l3l4, pT_2l_L, pT_2l_S, pT_4l; //Multi-lepton pT
+double invM_l1l2, invM_l3l4, invM_4l; //Multi-lepton invariant masses
+// TLorentzVector vec_e1, vec_e2, vec_e3, vec_e4, vec_u1, vec_u2, vec_u3, vec_u4, vec_l1l2, vec_l3l4, vec_4l; //lepton Lorentz vectors
+ROOT::Math::PtEtaPhiEVector vec_e1, vec_e2, vec_e3, vec_e4, vec_u1, vec_u2, vec_u3, vec_u4, vec_l1l2, vec_l3l4, vec_4l; //lepton PtEtaPhiE vectors
+
+/* Useful functions */
+// Order leading vs. subleading pT in a std::vector
+vector<double> get_lead_sublead_pT(double pT_1, double pT_2){
+    vector<double> pT_list;
+    if (pT_1 > pT_2) {pT_list = {pT_1, pT_2};}
+    else {pT_list = {pT_2, pT_1};}
+    return pT_list;
+}
+// Calculate angular distance, delta-R, between two objects
+double delta_R(double eta1, double eta2, double phi1, double phi2){
+    return sqrt( pow((eta1 - eta2), 2) + pow((phi1 - phi2), 2));
+}
+// Create TLorentzVector from a particle
+TLorentzVector get_Lorentz(const xAOD::TruthParticle* particle){
+    TLorentzVector particle_Lorentz;
+    particle_Lorentz.SetPxPyPzE(particle->px(), particle->py(), particle->pz(), particle->m());
+    return particle_Lorentz;
+}
+// Create PtEtaPhiEVector from a particle pointer
+ROOT::Math::PtEtaPhiEVector get_PtPtEtaPhiEVector(const xAOD::TruthParticle* particle){
+    return ROOT::Math::PtEtaPhiEVector particle_vector (particle->pT(), particle->eta(), particle->phi(), particle->e());
+}
+// Create PtEtaPhiEVector from doubles
+ROOT::Math::PtEtaPhiEVector get_PtPtEtaPhiEVector(double pT, double eta, double phi, double e){
+    ROOT::Math::PtEtaPhiEVector particle_vector(pT, eta, phi, e);
+    return particle_vector;
+}
 
 StatusCode MyxAODAnalysis :: execute ()
 {
@@ -171,7 +219,7 @@ StatusCode MyxAODAnalysis :: execute ()
             if (truth->hasDecayVtx()){
                 const xAOD::TruthVertex* decayVtx = truth->decayVtx();
                 if ( !(decayVtx -> nOutgoingParticles() == 2)){
-                    ANA_MSG_INFO("Higgs decaying in " << decayVtx->nOutgoingParticles() << " particles");
+                    // ANA_MSG_INFO("Higgs decaying in " << decayVtx->nOutgoingParticles() << " particles");
 
                     const xAOD::TruthParticle* H_child = decayVtx->outgoingParticle(0);
                     std::cout << "H_child pdgID: " << H_child->pdgId() << " ___ ";
@@ -197,7 +245,7 @@ StatusCode MyxAODAnalysis :: execute ()
                         //ANA_MSG_INFO("Dark Higgs 1 decays");
                         const xAOD::TruthVertex* S1_decayVtx = childS1->decayVtx();
                         const xAOD::TruthVertex* S2_decayVtx = childS2->decayVtx();
-                        ANA_MSG_INFO("Two S found");
+                        // ANA_MSG_INFO("Two S found");
                         n_S++;
 
                         //------------Label the 2nd gen children (Zd 1-4)------------
@@ -219,7 +267,7 @@ StatusCode MyxAODAnalysis :: execute ()
                                 const xAOD::TruthVertex* Zd2_decayVtx = childZd2->decayVtx();
                                 const xAOD::TruthVertex* Zd3_decayVtx = childZd3->decayVtx();
                                 const xAOD::TruthVertex* Zd4_decayVtx = childZd4->decayVtx();
-                                ANA_MSG_INFO("Four Zd found");
+                                // ANA_MSG_INFO("Four Zd found");
                                 n_Zd++;
 
                                 m_Zd1 = childZd1 -> m(); m_Zd2 = childZd2 -> m(); m_Zd3 = childZd3 -> m(); m_Zd4 = childZd4 -> m();
@@ -235,9 +283,25 @@ StatusCode MyxAODAnalysis :: execute ()
                                 const xAOD::TruthParticle* childl6 = Zd3_decayVtx->outgoingParticle(1);
                                 const xAOD::TruthParticle* childl7 = Zd4_decayVtx->outgoingParticle(0);
                                 const xAOD::TruthParticle* childl8 = Zd4_decayVtx->outgoingParticle(1);
+                                // Print pdgIDs
+                                cout << "[" << childl1->absPdgId() << " - " << childl2->absPdgId() << "]  ";
+                                cout << "[" << childl3->absPdgId() << " - " << childl4->absPdgId() << "]  ";
+                                cout << "[" << childl5->absPdgId() << " - " << childl6->absPdgId() << "]  ";
+                                cout << "[" << childl7->absPdgId() << " - " << childl8->absPdgId() << "]" << endl;;
 
-                                //We know these leptons will always be OSSF pairs, we only need to check 1 of each pair
-                                //Set bitmask
+                                /* Visible lepton kinematics
+                                Assumme the following:
+                                1. Leptons are always OSSF pairs
+                                2. Leptons 1-4 are always e/u, 5-8 are always v
+                                For each lepton 1-4 we store:
+                                1. pT
+                                2. eta
+                                3. phi
+                                4. energy
+                                5. PtEtaPhiEVector
+                                */
+
+                                // Set bitmask
                                 if (childl1->absPdgId()==11 || childl1->absPdgId()==13){l1_bool = true;}
                                 //if (childl2->absPdgId()==11 || childl2->absPdgId()==13){l2_bool = true;}
                                 if (childl3->absPdgId()==11 || childl3->absPdgId()==13){l3_bool = true;}
@@ -247,35 +311,66 @@ StatusCode MyxAODAnalysis :: execute ()
                                 if (childl7->absPdgId()==11 || childl7->absPdgId()==13){l7_bool = true;}
                                 //if (childl8->absPdgId()==11 || childl8->absPdgId()==13){l8_bool = true;}
 
-                                //Visible lepton kinematics
-                                //We also know that only leptons 1-4 will be e/u, while 5-8 while be v
+                                //Pair-12
                                 if (childl1->absPdgId()==11){
                                     pT_e1 = childl1 -> pt(); pT_e2 = childl2 -> pt();
                                     eta_e1 = childl1 -> eta(); eta_e2 = childl2 -> eta();
                                     phi_e1 = childl1 -> phi(); phi_e2 = childl2 -> phi();
+                                    e_e1 = childl1 -> e(); e_e2 = childl2 -> e();
+                                    vec_e1 = get_PtPtEtaPhiEVector(pT_e1, eta_e1, phi_e1, e_e1);
+                                    vec_e2 = get_PtPtEtaPhiEVector(pT_e2, eta_e2, phi_e2, e_e2);
+                                    vec_l1l2 = vec_e1 + vec_e2;
+                                    pT_l1l2 = pT_e1 + pT_e2;
+                                    
+                                    
                                 }
+                                elif (childl1->absPdgId()==13){
+                                    pT_u1 = childl1 -> pt(); pT_u2 = childl2 -> pt();
+                                    eta_u1 = childl1 -> eta(); eta_u2 = childl2 -> eta();
+                                    phi_u1 = childl1 -> phi(); phi_u2 = childl2 -> phi();
+                                    e_u1 = childl1 -> e(); e_u2 = childl2 -> e();
+                                    vec_u1 = get_PtPtEtaPhiEVector(pT_u1, eta_u1, phi_u1, e_u1);
+                                    vec_u2 = get_PtPtEtaPhiEVector(pT_u2, eta_u2, phi_u2, e_u2);
+                                    vec_l1l2 = vec_u1 + vec_u2;
+                                    pT_l1l2 = pT_u1 + pT_u2;
+                                    
+                                }
+                                //Pair-34
                                 if (childl3->absPdgId()==11){
                                     pT_e3 = childl3 -> pt(); pT_e4 = childl4 -> pt();
                                     eta_e3 = childl3 -> eta(); eta_e4 = childl4 -> eta();
                                     phi_e3 = childl3 -> phi(); phi_e4 = childl4 -> phi();
+                                    e_e3 = childl3 -> e(); e_e4 = childl4 -> e();
+                                    vec_e3 = get_PtPtEtaPhiEVector(pT_e3, eta_e3, phi_e3, e_e3);
+                                    vec_e4 = get_PtPtEtaPhiEVector(pT_e4, eta_e4, phi_e4, e_e4);
+                                    vec_l3l4 = vec_e3 + vec_e4;
+                                    pT_l3l4 = pT_e3 + pT_e4;
                                 }
-                                if (childl1->absPdgId()==13){
-                                    pT_u1 = childl1 -> pt(); pT_u2 = childl2 -> pt();
-                                    eta_u1 = childl1 -> eta(); eta_u2 = childl2 -> eta();
-                                    phi_u1 = childl1 -> phi(); phi_u2 = childl2 -> phi();
-                                }
-                                if (childl3->absPdgId()==13){
+                                elif (childl3->absPdgId()==13){
                                     pT_u3 = childl3 -> pt(); pT_u4 = childl4 -> pt();
                                     eta_u3 = childl3 -> eta(); eta_u4 = childl4 -> eta();
                                     phi_u3 = childl3 -> phi(); phi_u4 = childl4 -> phi();
+                                    e_u3 = childl3 -> e(); e_u4 = childl4 -> e();
+                                    vec_u3 = get_PtPtEtaPhiEVector(pT_u3, eta_u3, phi_u3, e_u3);
+                                    vec_u4 = get_PtPtEtaPhiEVector(pT_u4, eta_u4, phi_u4, e_u4);
+                                    vec_l3l4 = vec_u3 + vec_u4;
+                                    pT_l3l4 = pT_u3 + pT_u4;
                                 }
+                                //Determine leading and subleading pair
+                                pT_2l_L = get_lead_sublead_pT(pT_l1l2, pT_l3l4)[0];
+                                pT_2l_S = get_lead_sublead_pT(pT_l1l2, pT_l3l4)[1];
+                                //4l invariant mass
+                                invM_l1l2 = vec_l1l2.M()
+                                invM_l3l4 = vec_l3l4.M()
+                                invM_4l = (vec_l1l2 + vec_l3l4).M()
+
                             }//close Zd decay check
-                        }//close Zd check
+                        }//close Zd identity check
                     }//close S decay check                 
                     
-                }//close S check
+                }//close S identity check
             }//close Higgs decay check
-        }//close Higgs check
+        }//close Higgs identity check
         
         /*------------------------ SECTION 2 - BITMASK AND FILL HISTOGRAMS ------------------------*/
 
@@ -319,14 +414,16 @@ StatusCode MyxAODAnalysis :: execute ()
             hist ("h_phi_u1")->Fill (phi_u1); hist ("h_phi_u2")->Fill (phi_u2); hist ("h_phi_u3")->Fill (phi_u3); hist ("h_phi_u4")->Fill (phi_u4);
             hist ("h_eta_u1")->Fill (eta_u1); hist ("h_eta_u2")->Fill (eta_u2); hist ("h_eta_u3")->Fill (eta_u3); hist ("h_eta_u4")->Fill (eta_u4);
             hist ("h_pT_u1")->Fill (pT_u1/1000); hist ("h_pT_u2")->Fill (pT_u2/1000); hist ("h_pT_u3")->Fill (pT_u3/1000); hist ("h_pT_u4")->Fill (pT_u4/1000);
-            //Non-interacting MET
+            //MET
             const xAOD::MissingET* truthMET_NonInt = nullptr;
             truthMET_NonInt = (*truth_MET)["NonInt"];
-            hist ("h_missingET_NonInt")->Fill (truthMET_NonInt->met()/1000);
-            for ( auto MissingET : *truth_MET ){ hist ("h_missingET")->Fill (MissingET->sumet()/1000); } //Basic MET
-        }// Close 44 bitmask
+            hist ("h_missingET_NonInt")->Fill (truthMET_NonInt->met()/1000); // Non-interacting MET
+            for (auto MissingET : *truth_MET ){
+                hist ("h_missingET")->Fill (MissingET->sumet()/1000); // Basic MET
+            }
+        }//Close 44 bitmask
 
-        //check 22 case
+        //Check 22 case
         if (bitmask == 5 || bitmask == 6 || bitmask == 9 || bitmask == 10 ){
             l_multiplicity ++;
             l_multiplicity_22 ++;
@@ -334,14 +431,6 @@ StatusCode MyxAODAnalysis :: execute ()
         }//Close 22 bitmask
         
     }//close for loop
-
-    //Scaling Histograms
-    // std::cout << "Method 1: fill then scale" << std::endl; //The scaled histogram doesn't seem to save so we are left with the original
-    // h_missingET_Yscaled1->Scale(norm_factor);
-    // std::cout << "Method 2: set to NonInt then scale" << std::endl;
-    // h_missingET_Yscaled2 = h_missingET_NonInt; //This histogram ends up empty
-    // h_missingET_Yscaled2->Scale(norm_factor);
-    // std::cout << "Scaling Done" << std::endl;
 
     return StatusCode::SUCCESS;
 }//close execute loop

--- a/analysis/basic-analysis/event-analysis.cxx
+++ b/analysis/basic-analysis/event-analysis.cxx
@@ -64,36 +64,36 @@ StatusCode MyxAODAnalysis :: initialize ()
 //    ANA_CHECK(event->writeTo(file));
 
     //Progenitor (H)
-    ANA_CHECK (book (TH1D("h_m_H", "h_m_H", 100, 0, 1000)));
-    ANA_CHECK (book (TH1D("h_pT_H", "h_pT_H", 100, 0, 500)));
-    ANA_CHECK (book (TH1D("h_eta_H","h_eta_H", 100, -5.5, 5.5)));
-    ANA_CHECK (book (TH1D("h_phi_H", "h_phi_H", 100, -4.5, 4.5)));
+    ANA_CHECK (book (TH1D("h_m_H", "h_m_H", 100, 0, 1500)));
+    ANA_CHECK (book (TH1D("h_pT_H", "h_pT_H", 100, 0, 1500)));
+    ANA_CHECK (book (TH1D("h_eta_H","h_eta_H", 100, -6.5, 6.5)));
+    ANA_CHECK (book (TH1D("h_phi_H", "h_phi_H", 100, -4, 4)));
     //Additional Scalar (S)
     ANA_CHECK (book (TH1D("h_m_S1", "h_m_S1", 100, 0, 200)));
     ANA_CHECK (book (TH1D("h_m_S2", "h_m_S2", 100, 0, 200)));
-    ANA_CHECK (book (TH1D("h_pT_S1", "h_pT_S1", 100, 0, 500)));
-    ANA_CHECK (book (TH1D("h_pT_S2", "h_pT_S2", 100, 0, 500)));
+    ANA_CHECK (book (TH1D("h_pT_S1", "h_pT_S1", 100, 0, 1000)));
+    ANA_CHECK (book (TH1D("h_pT_S2", "h_pT_S2", 100, 0, 1000)));
     ANA_CHECK (book (TH1D("h_eta_S1","h_eta_S1", 100, -4.5, 4.5)));
     ANA_CHECK (book (TH1D("h_eta_S2","h_eta_S2", 100, -4.5, 4.5)));
-    ANA_CHECK (book (TH1D("h_phi_S1", "h_phi_S1", 100, -4.5, 4.5)));
-    ANA_CHECK (book (TH1D("h_phi_S2", "h_phi_S2", 100, -4.5, 4.5)));
+    ANA_CHECK (book (TH1D("h_phi_S1", "h_phi_S1", 100, -4, 4)));
+    ANA_CHECK (book (TH1D("h_phi_S2", "h_phi_S2", 100, -4, 4)));
     //Dark Vector Boson (Zd)
     ANA_CHECK (book (TH1D("h_m_Zd1", "h_m_Zd1", 100, 0, 200)));
     ANA_CHECK (book (TH1D("h_m_Zd2", "h_m_Zd2", 100, 0, 200)));
     ANA_CHECK (book (TH1D("h_m_Zd3", "h_m_Zd3", 100, 0, 200)));
     ANA_CHECK (book (TH1D("h_m_Zd4", "h_m_Zd4", 100, 0, 200)));
-    ANA_CHECK (book (TH1D("h_pT_Zd1", "h_pT_Zd1", 100, 0, 500)));
-    ANA_CHECK (book (TH1D("h_pT_Zd2", "h_pT_Zd2", 100, 0, 500)));
-    ANA_CHECK (book (TH1D("h_pT_Zd3", "h_pT_Zd3", 100, 0, 500)));
-    ANA_CHECK (book (TH1D("h_pT_Zd4", "h_pT_Zd4", 100, 0, 500)));
+    ANA_CHECK (book (TH1D("h_pT_Zd1", "h_pT_Zd1", 100, 0, 1000)));
+    ANA_CHECK (book (TH1D("h_pT_Zd2", "h_pT_Zd2", 100, 0, 1000)));
+    ANA_CHECK (book (TH1D("h_pT_Zd3", "h_pT_Zd3", 100, 0, 1000)));
+    ANA_CHECK (book (TH1D("h_pT_Zd4", "h_pT_Zd4", 100, 0, 1000)));
     ANA_CHECK (book (TH1D("h_eta_Zd1","h_eta_Zd1", 100, -4.5, 4.5)));
     ANA_CHECK (book (TH1D("h_eta_Zd2","h_eta_Zd2", 100, -4.5, 4.5)));
     ANA_CHECK (book (TH1D("h_eta_Zd3","h_eta_Zd3", 100, -4.5, 4.5)));
     ANA_CHECK (book (TH1D("h_eta_Zd4","h_eta_Zd4", 100, -4.5, 4.5)));
-    ANA_CHECK (book (TH1D("h_phi_Zd1", "h_phi_Zd1", 100, -4.5, 4.5)));
-    ANA_CHECK (book (TH1D("h_phi_Zd2", "h_phi_Zd2", 100, -4.5, 4.5)));
-    ANA_CHECK (book (TH1D("h_phi_Zd3", "h_phi_Zd3", 100, -4.5, 4.5)));
-    ANA_CHECK (book (TH1D("h_phi_Zd4", "h_phi_Zd4", 100, -4.5, 4.5)));
+    ANA_CHECK (book (TH1D("h_phi_Zd1", "h_phi_Zd1", 100, -4, 4)));
+    ANA_CHECK (book (TH1D("h_phi_Zd2", "h_phi_Zd2", 100, -4, 4)));
+    ANA_CHECK (book (TH1D("h_phi_Zd3", "h_phi_Zd3", 100, -4, 4)));
+    ANA_CHECK (book (TH1D("h_phi_Zd4", "h_phi_Zd4", 100, -4, 4)));
     //Visible leptons (e; u;)
     ANA_CHECK (book (TH1D("h_pT_e1", "h_pT_e1", 100, 0, 500))); ANA_CHECK (book (TH1D("h_pT_u1", "h_pT_u1", 100, 0, 500))); //pT
     ANA_CHECK (book (TH1D("h_pT_e2", "h_pT_e2", 100, 0, 500))); ANA_CHECK (book (TH1D("h_pT_u2", "h_pT_u2", 100, 0, 500)));
@@ -103,24 +103,22 @@ StatusCode MyxAODAnalysis :: initialize ()
     ANA_CHECK (book (TH1D("h_eta_e2","h_eta_e2", 100, -4.5, 4.5))); ANA_CHECK (book (TH1D("h_eta_u2","h_eta_u2", 100, -4.5, 4.5)));
     ANA_CHECK (book (TH1D("h_eta_e3","h_eta_e3", 100, -4.5, 4.5))); ANA_CHECK (book (TH1D("h_eta_u3","h_eta_u3", 100, -4.5, 4.5)));
     ANA_CHECK (book (TH1D("h_eta_e4","h_eta_e4", 100, -4.5, 4.5))); ANA_CHECK (book (TH1D("h_eta_u4","h_eta_u4", 100, -4.5, 4.5)));
-    ANA_CHECK (book (TH1D("h_phi_e1","h_phi_e1", 100, -4.5, 4.5))); ANA_CHECK (book (TH1D("h_phi_u1","h_phi_u1", 100, -4.5, 4.5))); //phi
-    ANA_CHECK (book (TH1D("h_phi_e2","h_phi_e2", 100, -4.5, 4.5))); ANA_CHECK (book (TH1D("h_phi_u2","h_phi_u2", 100, -4.5, 4.5)));
-    ANA_CHECK (book (TH1D("h_phi_e3","h_phi_e3", 100, -4.5, 4.5))); ANA_CHECK (book (TH1D("h_phi_u3","h_phi_u3", 100, -4.5, 4.5)));
-    ANA_CHECK (book (TH1D("h_phi_e4","h_phi_e4", 100, -4.5, 4.5))); ANA_CHECK (book (TH1D("h_phi_u4","h_phi_u4", 100, -4.5, 4.5)));
+    ANA_CHECK (book (TH1D("h_phi_e1","h_phi_e1", 100, -4, 4))); ANA_CHECK (book (TH1D("h_phi_u1","h_phi_u1", 100, -4, 4))); //phi
+    ANA_CHECK (book (TH1D("h_phi_e2","h_phi_e2", 100, -4, 4))); ANA_CHECK (book (TH1D("h_phi_u2","h_phi_u2", 100, -4, 4)));
+    ANA_CHECK (book (TH1D("h_phi_e3","h_phi_e3", 100, -4, 4))); ANA_CHECK (book (TH1D("h_phi_u3","h_phi_u3", 100, -4, 4)));
+    ANA_CHECK (book (TH1D("h_phi_e4","h_phi_e4", 100, -4, 4))); ANA_CHECK (book (TH1D("h_phi_u4","h_phi_u4", 100, -4, 4)));
     //Multileptons
-    // ANA_CHECK (book (TH1D("h_pT_lead", "h_pT_lead", 100, 0, 500)));
-    // ANA_CHECK (book (TH1D("h_pT_sublead", "h_pT_sublead", 100, 0, 500)));
+    ANA_CHECK (book (TH1D("h_invMass_l1l2", "h_invMass_l1l2", 100, 0, 200)));
+    ANA_CHECK (book (TH1D("h_invMass_l3l4", "h_invMass_l3l4", 100, 0, 200)));
+    ANA_CHECK (book (TH1D("h_invMass_4l", "h_invMass_4l", 100, 0, 200)));
+    ANA_CHECK (book (TH1D("h_pT_2l_leading", "h_pT_2l_leading", 100, 0, 1000)));
+    ANA_CHECK (book (TH1D("h_pT_2l_subleading", "h_pT_2l_subleading", 100, 0, 500)));
+    ANA_CHECK (book (TH1D("h_pT_4l", "h_pT_4l", 100, 0, 1000)));
     //MET
     ANA_CHECK (book (TH1F("h_missingET","h_missingET",100,0,1000)));
     ANA_CHECK (book (TH1D("h_missingET_NonInt","h_missingET_NonInt",100,0,1000)));
 
     //Testing
-    ANA_CHECK (book (TH1D("h_invMass_l1l2", "h_invMass_l1l2", 100, 0, 200)));
-    ANA_CHECK (book (TH1D("h_invMass_l3l4", "h_invMass_l3l4", 100, 0, 200)));
-    ANA_CHECK (book (TH1D("h_invMass_4l", "h_invMass_4l", 100, 0, 200)));
-    ANA_CHECK (book (TH1D("h_pT_2l_leading", "h_pT_2l_leading", 100, 0, 500)));
-    ANA_CHECK (book (TH1D("h_pT_2l_subleading", "h_pT_2l_subleading", 100, 0, 500)));
-    ANA_CHECK (book (TH1D("h_pT_4l", "h_pT_4l", 100, 0, 1000)));
 
     return StatusCode::SUCCESS;
 }

--- a/analysis/basic-analysis/event-analysis.cxx
+++ b/analysis/basic-analysis/event-analysis.cxx
@@ -95,34 +95,32 @@ StatusCode MyxAODAnalysis :: initialize ()
     ANA_CHECK (book (TH1D("h_phi_Zd3", "h_phi_Zd3", 100, -4.5, 4.5)));
     ANA_CHECK (book (TH1D("h_phi_Zd4", "h_phi_Zd4", 100, -4.5, 4.5)));
     //Visible leptons (e; u;)
-    ANA_CHECK (book (TH1D("h_pT_e1", "h_pT_e1", 100, 0, 500))); ANA_CHECK (book (TH1D("h_pT_u1", "h_pT_u1", 100, 0, 500)));
+    ANA_CHECK (book (TH1D("h_pT_e1", "h_pT_e1", 100, 0, 500))); ANA_CHECK (book (TH1D("h_pT_u1", "h_pT_u1", 100, 0, 500))); //pT
     ANA_CHECK (book (TH1D("h_pT_e2", "h_pT_e2", 100, 0, 500))); ANA_CHECK (book (TH1D("h_pT_u2", "h_pT_u2", 100, 0, 500)));
     ANA_CHECK (book (TH1D("h_pT_e3", "h_pT_e3", 100, 0, 500))); ANA_CHECK (book (TH1D("h_pT_u3", "h_pT_u3", 100, 0, 500)));
     ANA_CHECK (book (TH1D("h_pT_e4", "h_pT_e4", 100, 0, 500))); ANA_CHECK (book (TH1D("h_pT_u4", "h_pT_u4", 100, 0, 500)));
-    ANA_CHECK (book (TH1D("h_eta_e1","h_eta_e1", 100, -4.5, 4.5))); ANA_CHECK (book (TH1D("h_eta_u1","h_eta_u1", 100, -4.5, 4.5)));
+    ANA_CHECK (book (TH1D("h_eta_e1","h_eta_e1", 100, -4.5, 4.5))); ANA_CHECK (book (TH1D("h_eta_u1","h_eta_u1", 100, -4.5, 4.5))); //eta
     ANA_CHECK (book (TH1D("h_eta_e2","h_eta_e2", 100, -4.5, 4.5))); ANA_CHECK (book (TH1D("h_eta_u2","h_eta_u2", 100, -4.5, 4.5)));
     ANA_CHECK (book (TH1D("h_eta_e3","h_eta_e3", 100, -4.5, 4.5))); ANA_CHECK (book (TH1D("h_eta_u3","h_eta_u3", 100, -4.5, 4.5)));
     ANA_CHECK (book (TH1D("h_eta_e4","h_eta_e4", 100, -4.5, 4.5))); ANA_CHECK (book (TH1D("h_eta_u4","h_eta_u4", 100, -4.5, 4.5)));
-    ANA_CHECK (book (TH1D("h_phi_e1","h_phi_e1", 100, -4.5, 4.5))); ANA_CHECK (book (TH1D("h_phi_u1","h_phi_u1", 100, -4.5, 4.5)));
+    ANA_CHECK (book (TH1D("h_phi_e1","h_phi_e1", 100, -4.5, 4.5))); ANA_CHECK (book (TH1D("h_phi_u1","h_phi_u1", 100, -4.5, 4.5))); //phi
     ANA_CHECK (book (TH1D("h_phi_e2","h_phi_e2", 100, -4.5, 4.5))); ANA_CHECK (book (TH1D("h_phi_u2","h_phi_u2", 100, -4.5, 4.5)));
     ANA_CHECK (book (TH1D("h_phi_e3","h_phi_e3", 100, -4.5, 4.5))); ANA_CHECK (book (TH1D("h_phi_u3","h_phi_u3", 100, -4.5, 4.5)));
     ANA_CHECK (book (TH1D("h_phi_e4","h_phi_e4", 100, -4.5, 4.5))); ANA_CHECK (book (TH1D("h_phi_u4","h_phi_u4", 100, -4.5, 4.5)));
     //Multileptons
-    ANA_CHECK (book (TH1D("h_pT_lead", "h_pT_lead", 100, 0, 500)));
-    ANA_CHECK (book (TH1D("h_pT_sublead", "h_pT_sublead", 100, 0, 500)));
+    // ANA_CHECK (book (TH1D("h_pT_lead", "h_pT_lead", 100, 0, 500)));
+    // ANA_CHECK (book (TH1D("h_pT_sublead", "h_pT_sublead", 100, 0, 500)));
     //MET
     ANA_CHECK (book (TH1F("h_missingET","h_missingET",100,0,1000)));
     ANA_CHECK (book (TH1D("h_missingET_NonInt","h_missingET_NonInt",100,0,1000)));
 
     //Testing
-    // ANA_CHECK (book (TH1D("h_M_S1", "h_M_S1", 100, 0, 200)));
-    // ANA_CHECK (book (TH1D("h_M_Zd1", "h_M_Zd1", 100, 0, 200)));
-    // ANA_CHECK (book (TH1D("h_invMass_l1l2", "h_invMass_l1l2", 100, 0, 200)));
-    // ANA_CHECK (book (TH1D("h_invMass_l3l4", "h_invMass_l3l4", 100, 0, 200)));
-    // ANA_CHECK (book (TH1D("h_invMass_4l", "h_invMass_4l", 100, 0, 200)));
-    // ANA_CHECK (book (TH1D("h_vectorInvMass_l1l2", "h_vectorInvMass_l1l2", 100, 0, 200)));
-    // ANA_CHECK (book (TH1D("h_vectorInvMass_l3l4", "h_vectorInvMass_l3l4", 100, 0, 200)));
-    // ANA_CHECK (book (TH1D("h_vectorInvMass_4l", "h_vectorInvMass_4l", 100, 0, 200)));
+    ANA_CHECK (book (TH1D("h_invMass_l1l2", "h_invMass_l1l2", 100, 0, 200)));
+    ANA_CHECK (book (TH1D("h_invMass_l3l4", "h_invMass_l3l4", 100, 0, 200)));
+    ANA_CHECK (book (TH1D("h_invMass_4l", "h_invMass_4l", 100, 0, 200)));
+    ANA_CHECK (book (TH1D("h_pT_2l_leading", "h_pT_2l_leading", 100, 0, 500)));
+    ANA_CHECK (book (TH1D("h_pT_2l_subleading", "h_pT_2l_subleading", 100, 0, 500)));
+    ANA_CHECK (book (TH1D("h_pT_4l", "h_pT_4l", 100, 0, 500)));
 
     return StatusCode::SUCCESS;
 }
@@ -147,7 +145,7 @@ double pT_e1, pT_e2, pT_e3, pT_e4, eta_e1, eta_e2, eta_e3, eta_e4, phi_e1, phi_e
 double pT_u1, pT_u2, pT_u3, pT_u4, eta_u1, eta_u2, eta_u3, eta_u4, phi_u1, phi_u2, phi_u3, phi_u4; //muon pT, eta, phi
 double e_e1, e_e2, e_e3, e_e4, px_e1, px_e2, px_e3, px_e4, py_e1, py_e2, py_e3, py_e4, pz_e1, pz_e2, pz_e3, pz_e4; //electron e, px, py, pz
 double e_u1, e_u2, e_u3, e_u4, px_u1, px_u2, px_u3, px_u4, py_u1, py_u2, py_u3, py_u4, pz_u1, pz_u2, pz_u3, pz_u4; //muon e, px, py, pz
-double pT_l1l2, pT_l3l4, pT_2l_L, pT_2l_S, pT_4l; //Multi-lepton pT
+double pT_l1l2, pT_l3l4, pT_2l_Lead, pT_2l_Sublead, pT_4l; //Multi-lepton pT
 double invM_l1l2, invM_l3l4, invM_4l; //Multi-lepton invariant masses
 // TLorentzVector vec_e1, vec_e2, vec_e3, vec_e4, vec_u1, vec_u2, vec_u3, vec_u4, vec_l1l2, vec_l3l4, vec_4l; //lepton Lorentz vectors
 ROOT::Math::PtEtaPhiEVector vec_e1, vec_e2, vec_e3, vec_e4, vec_u1, vec_u2, vec_u3, vec_u4, vec_l1l2, vec_l3l4, vec_4l; //lepton PtEtaPhiE vectors
@@ -171,11 +169,11 @@ TLorentzVector get_Lorentz(const xAOD::TruthParticle* particle){
     return particle_Lorentz;
 }
 // Create PtEtaPhiEVector from a particle pointer
-ROOT::Math::PtEtaPhiEVector get_PtPtEtaPhiEVector(const xAOD::TruthParticle* particle){
-    return ROOT::Math::PtEtaPhiEVector particle_vector (particle->pT(), particle->eta(), particle->phi(), particle->e());
-}
+// ROOT::Math::PtEtaPhiEVector get_PtEtaPhiEVector(const xAOD::TruthParticle* particle){
+//     return ROOT::Math::PtEtaPhiEVector particle_vector (particle->pT(), particle->eta(), particle->phi(), particle->e());
+// }
 // Create PtEtaPhiEVector from doubles
-ROOT::Math::PtEtaPhiEVector get_PtPtEtaPhiEVector(double pT, double eta, double phi, double e){
+ROOT::Math::PtEtaPhiEVector get_PtEtaPhiEVector(double pT, double eta, double phi, double e){
     ROOT::Math::PtEtaPhiEVector particle_vector(pT, eta, phi, e);
     return particle_vector;
 }
@@ -284,10 +282,10 @@ StatusCode MyxAODAnalysis :: execute ()
                                 const xAOD::TruthParticle* childl7 = Zd4_decayVtx->outgoingParticle(0);
                                 const xAOD::TruthParticle* childl8 = Zd4_decayVtx->outgoingParticle(1);
                                 // Print pdgIDs
-                                cout << "[" << childl1->absPdgId() << " - " << childl2->absPdgId() << "]  ";
-                                cout << "[" << childl3->absPdgId() << " - " << childl4->absPdgId() << "]  ";
-                                cout << "[" << childl5->absPdgId() << " - " << childl6->absPdgId() << "]  ";
-                                cout << "[" << childl7->absPdgId() << " - " << childl8->absPdgId() << "]" << endl;;
+                                cout << "[" << childl1->pdgId() << ", " << childl2->pdgId() << "]  ";
+                                cout << "[" << childl3->pdgId() << ", " << childl4->pdgId() << "]  ";
+                                cout << "[" << childl5->pdgId() << ", " << childl6->pdgId() << "]  ";
+                                cout << "[" << childl7->pdgId() << ", " << childl8->pdgId() << "]" << endl;;
 
                                 /* Visible lepton kinematics
                                 Assumme the following:
@@ -317,23 +315,20 @@ StatusCode MyxAODAnalysis :: execute ()
                                     eta_e1 = childl1 -> eta(); eta_e2 = childl2 -> eta();
                                     phi_e1 = childl1 -> phi(); phi_e2 = childl2 -> phi();
                                     e_e1 = childl1 -> e(); e_e2 = childl2 -> e();
-                                    vec_e1 = get_PtPtEtaPhiEVector(pT_e1, eta_e1, phi_e1, e_e1);
-                                    vec_e2 = get_PtPtEtaPhiEVector(pT_e2, eta_e2, phi_e2, e_e2);
+                                    vec_e1 = get_PtEtaPhiEVector(pT_e1, eta_e1, phi_e1, e_e1);
+                                    vec_e2 = get_PtEtaPhiEVector(pT_e2, eta_e2, phi_e2, e_e2);
                                     vec_l1l2 = vec_e1 + vec_e2;
                                     pT_l1l2 = pT_e1 + pT_e2;
-                                    
-                                    
                                 }
-                                elif (childl1->absPdgId()==13){
+                                if (childl1->absPdgId()==13){
                                     pT_u1 = childl1 -> pt(); pT_u2 = childl2 -> pt();
                                     eta_u1 = childl1 -> eta(); eta_u2 = childl2 -> eta();
                                     phi_u1 = childl1 -> phi(); phi_u2 = childl2 -> phi();
                                     e_u1 = childl1 -> e(); e_u2 = childl2 -> e();
-                                    vec_u1 = get_PtPtEtaPhiEVector(pT_u1, eta_u1, phi_u1, e_u1);
-                                    vec_u2 = get_PtPtEtaPhiEVector(pT_u2, eta_u2, phi_u2, e_u2);
+                                    vec_u1 = get_PtEtaPhiEVector(pT_u1, eta_u1, phi_u1, e_u1);
+                                    vec_u2 = get_PtEtaPhiEVector(pT_u2, eta_u2, phi_u2, e_u2);
                                     vec_l1l2 = vec_u1 + vec_u2;
                                     pT_l1l2 = pT_u1 + pT_u2;
-                                    
                                 }
                                 //Pair-34
                                 if (childl3->absPdgId()==11){
@@ -341,28 +336,31 @@ StatusCode MyxAODAnalysis :: execute ()
                                     eta_e3 = childl3 -> eta(); eta_e4 = childl4 -> eta();
                                     phi_e3 = childl3 -> phi(); phi_e4 = childl4 -> phi();
                                     e_e3 = childl3 -> e(); e_e4 = childl4 -> e();
-                                    vec_e3 = get_PtPtEtaPhiEVector(pT_e3, eta_e3, phi_e3, e_e3);
-                                    vec_e4 = get_PtPtEtaPhiEVector(pT_e4, eta_e4, phi_e4, e_e4);
+                                    vec_e3 = get_PtEtaPhiEVector(pT_e3, eta_e3, phi_e3, e_e3);
+                                    vec_e4 = get_PtEtaPhiEVector(pT_e4, eta_e4, phi_e4, e_e4);
                                     vec_l3l4 = vec_e3 + vec_e4;
                                     pT_l3l4 = pT_e3 + pT_e4;
                                 }
-                                elif (childl3->absPdgId()==13){
+                                if (childl3->absPdgId()==13){
                                     pT_u3 = childl3 -> pt(); pT_u4 = childl4 -> pt();
                                     eta_u3 = childl3 -> eta(); eta_u4 = childl4 -> eta();
                                     phi_u3 = childl3 -> phi(); phi_u4 = childl4 -> phi();
                                     e_u3 = childl3 -> e(); e_u4 = childl4 -> e();
-                                    vec_u3 = get_PtPtEtaPhiEVector(pT_u3, eta_u3, phi_u3, e_u3);
-                                    vec_u4 = get_PtPtEtaPhiEVector(pT_u4, eta_u4, phi_u4, e_u4);
+                                    vec_u3 = get_PtEtaPhiEVector(pT_u3, eta_u3, phi_u3, e_u3);
+                                    vec_u4 = get_PtEtaPhiEVector(pT_u4, eta_u4, phi_u4, e_u4);
                                     vec_l3l4 = vec_u3 + vec_u4;
                                     pT_l3l4 = pT_u3 + pT_u4;
                                 }
                                 //Determine leading and subleading pair
-                                pT_2l_L = get_lead_sublead_pT(pT_l1l2, pT_l3l4)[0];
-                                pT_2l_S = get_lead_sublead_pT(pT_l1l2, pT_l3l4)[1];
+                                pT_2l_Lead = get_lead_sublead_pT(pT_l1l2, pT_l3l4)[0];
+                                pT_2l_Sublead = get_lead_sublead_pT(pT_l1l2, pT_l3l4)[1];
                                 //4l invariant mass
-                                invM_l1l2 = vec_l1l2.M()
-                                invM_l3l4 = vec_l3l4.M()
-                                invM_4l = (vec_l1l2 + vec_l3l4).M()
+                                invM_l1l2 = vec_l1l2.M();
+                                invM_l3l4 = vec_l3l4.M();
+                                invM_4l = (vec_l1l2 + vec_l3l4).M();
+
+                                int bitmask_test = pow(2,3)*l1_bool + pow(2,2)*l3_bool + pow(2,1)*l5_bool + pow(2,0)*l7_bool;
+                                cout << "Bitmask value: " << bitmask_test << endl;
 
                             }//close Zd decay check
                         }//close Zd identity check
@@ -392,35 +390,44 @@ StatusCode MyxAODAnalysis :: execute ()
 
             //------------ Fill Kinematic Hists ------------//
             //H
-            hist ("h_m_H")->Fill (m_H/1000);
-            hist ("h_phi_H")->Fill (phi_H);
-            hist ("h_eta_H")->Fill (eta_H);
-            hist ("h_pT_H")->Fill (pT_H/1000);
+            hist ("h_m_H") -> Fill(m_H/1000);
+            hist ("h_phi_H") -> Fill(phi_H);
+            hist ("h_eta_H") -> Fill(eta_H);
+            hist ("h_pT_H") -> Fill(pT_H/1000);
             //S
-            hist ("h_m_S1")->Fill (m_S1/1000); hist ("h_m_S2")->Fill (m_S2/1000);
-            hist ("h_phi_S1")->Fill (phi_S1); hist ("h_phi_S2")->Fill (phi_S2);
-            hist ("h_eta_S1")->Fill (eta_S1); hist ("h_eta_S2")->Fill (eta_S2);
-            hist ("h_pT_S1")->Fill (pT_S1/1000); hist ("h_pT_S2")->Fill (pT_S2/1000);
+            hist ("h_m_S1") -> Fill(m_S1/1000); hist ("h_m_S2") -> Fill(m_S2/1000);
+            hist ("h_phi_S1") -> Fill(phi_S1); hist ("h_phi_S2") -> Fill(phi_S2);
+            hist ("h_eta_S1") -> Fill(eta_S1); hist ("h_eta_S2") -> Fill(eta_S2);
+            hist ("h_pT_S1") -> Fill(pT_S1/1000); hist ("h_pT_S2") -> Fill(pT_S2/1000);
             //Zd
-            hist ("h_m_Zd1")->Fill (m_Zd1/1000); hist ("h_m_Zd2")->Fill (m_Zd2/1000); hist ("h_m_Zd3")->Fill (m_Zd3/1000); hist ("h_m_Zd4")->Fill (m_Zd4/1000);
-            hist ("h_phi_Zd1")->Fill (phi_Zd1); hist ("h_phi_Zd2")->Fill (phi_Zd2); hist ("h_phi_Zd3")->Fill (phi_Zd3); hist ("h_phi_Zd4")->Fill (phi_Zd4);
-            hist ("h_eta_Zd1")->Fill (eta_Zd1); hist ("h_eta_Zd2")->Fill (eta_Zd2); hist ("h_eta_Zd3")->Fill (eta_Zd3); hist ("h_eta_Zd4")->Fill (eta_Zd4);
-            hist ("h_pT_Zd1")->Fill (pT_Zd1/1000); hist ("h_pT_Zd2")->Fill (pT_Zd2/1000); hist ("h_pT_Zd3")->Fill (pT_Zd3/1000); hist ("h_pT_Zd4")->Fill (pT_Zd4/1000);
+            hist ("h_m_Zd1") -> Fill(m_Zd1/1000); hist ("h_m_Zd2") -> Fill(m_Zd2/1000); hist ("h_m_Zd3") -> Fill(m_Zd3/1000); hist ("h_m_Zd4") -> Fill(m_Zd4/1000);
+            hist ("h_phi_Zd1") -> Fill(phi_Zd1); hist ("h_phi_Zd2") -> Fill(phi_Zd2); hist ("h_phi_Zd3") -> Fill(phi_Zd3); hist ("h_phi_Zd4") -> Fill(phi_Zd4);
+            hist ("h_eta_Zd1") -> Fill(eta_Zd1); hist ("h_eta_Zd2") -> Fill(eta_Zd2); hist ("h_eta_Zd3") -> Fill(eta_Zd3); hist ("h_eta_Zd4") -> Fill(eta_Zd4);
+            hist ("h_pT_Zd1") -> Fill(pT_Zd1/1000); hist ("h_pT_Zd2") -> Fill(pT_Zd2/1000); hist ("h_pT_Zd3") -> Fill(pT_Zd3/1000); hist ("h_pT_Zd4") -> Fill(pT_Zd4/1000);
             //Electrons
-            hist ("h_phi_e1")->Fill (phi_e1); hist ("h_phi_e2")->Fill (phi_e2); hist ("h_phi_e3")->Fill (phi_e3); hist ("h_phi_e4")->Fill (phi_e4);
-            hist ("h_eta_e1")->Fill (eta_e1); hist ("h_eta_e2")->Fill (eta_e2); hist ("h_eta_e3")->Fill (eta_e3); hist ("h_eta_e4")->Fill (eta_e4);
-            hist ("h_pT_e1")->Fill (pT_e1/1000); hist ("h_pT_e2")->Fill (pT_e2/1000); hist ("h_pT_e3")->Fill (pT_e3/1000); hist ("h_pT_e4")->Fill (pT_e4/1000);
+            hist ("h_phi_e1") -> Fill(phi_e1); hist ("h_phi_e2") -> Fill(phi_e2); hist ("h_phi_e3") -> Fill(phi_e3); hist ("h_phi_e4") -> Fill(phi_e4);
+            hist ("h_eta_e1") -> Fill(eta_e1); hist ("h_eta_e2") -> Fill(eta_e2); hist ("h_eta_e3") -> Fill(eta_e3); hist ("h_eta_e4") -> Fill(eta_e4);
+            hist ("h_pT_e1") -> Fill(pT_e1/1000); hist ("h_pT_e2") -> Fill(pT_e2/1000); hist ("h_pT_e3") -> Fill(pT_e3/1000); hist ("h_pT_e4") -> Fill(pT_e4/1000);
             //Muons
-            hist ("h_phi_u1")->Fill (phi_u1); hist ("h_phi_u2")->Fill (phi_u2); hist ("h_phi_u3")->Fill (phi_u3); hist ("h_phi_u4")->Fill (phi_u4);
-            hist ("h_eta_u1")->Fill (eta_u1); hist ("h_eta_u2")->Fill (eta_u2); hist ("h_eta_u3")->Fill (eta_u3); hist ("h_eta_u4")->Fill (eta_u4);
-            hist ("h_pT_u1")->Fill (pT_u1/1000); hist ("h_pT_u2")->Fill (pT_u2/1000); hist ("h_pT_u3")->Fill (pT_u3/1000); hist ("h_pT_u4")->Fill (pT_u4/1000);
+            hist ("h_phi_u1") -> Fill(phi_u1); hist ("h_phi_u2") -> Fill(phi_u2); hist ("h_phi_u3") -> Fill(phi_u3); hist ("h_phi_u4") -> Fill(phi_u4);
+            hist ("h_eta_u1") -> Fill(eta_u1); hist ("h_eta_u2") -> Fill(eta_u2); hist ("h_eta_u3") -> Fill(eta_u3); hist ("h_eta_u4") -> Fill(eta_u4);
+            hist ("h_pT_u1") -> Fill(pT_u1/1000); hist ("h_pT_u2") -> Fill(pT_u2/1000); hist ("h_pT_u3") -> Fill(pT_u3/1000); hist ("h_pT_u4") -> Fill(pT_u4/1000);
             //MET
             const xAOD::MissingET* truthMET_NonInt = nullptr;
             truthMET_NonInt = (*truth_MET)["NonInt"];
-            hist ("h_missingET_NonInt")->Fill (truthMET_NonInt->met()/1000); // Non-interacting MET
+            hist ("h_missingET_NonInt") -> Fill(truthMET_NonInt->met()/1000); // Non-interacting MET
             for (auto MissingET : *truth_MET ){
-                hist ("h_missingET")->Fill (MissingET->sumet()/1000); // Basic MET
+                hist ("h_missingET") -> Fill(MissingET->sumet()/1000); // Basic MET
             }
+
+            //TEST HISTS
+            hist ("h_invMass_l1l2") -> Fill(invM_l1l2/1000);
+            hist ("h_invMass_l3l4") -> Fill(invM_l3l4/1000);
+            hist ("h_invMass_4l") -> Fill(invM_4l/1000);
+            hist ("h_pT_2l_leading") -> Fill(pT_2l_Lead/1000);
+            hist ("h_pT_2l_subleading") -> Fill(pT_2l_Sublead/1000);
+            hist ("h_pT_4l") -> Fill(pT_4l/1000);
+            
         }//Close 44 bitmask
 
         //Check 22 case
@@ -449,8 +456,6 @@ StatusCode MyxAODAnalysis :: finalize ()
     std::cout << "Bitmask 3:\t" << l_multiplicity_3 << "\n";
     std::cout << "Bitmask 12:\t" << l_multiplicity_12 << "\n";
     std::cout << "Total 44:\t" << l_multiplicity_44 << "\n";
-
-    // !!! Add check for PdgID of each of l1-8 !!!
 
     std::cout << "\n\n\n";
     return StatusCode::SUCCESS;

--- a/analysis/basic-analysis/event-analysis.cxx
+++ b/analysis/basic-analysis/event-analysis.cxx
@@ -64,9 +64,9 @@ StatusCode MyxAODAnalysis :: initialize ()
 //    ANA_CHECK(event->writeTo(file));
 
     //Progenitor (H)
-    ANA_CHECK (book (TH1D("h_m_H", "h_m_H", 100, 0, 900)));
+    ANA_CHECK (book (TH1D("h_m_H", "h_m_H", 100, 0, 1000)));
     ANA_CHECK (book (TH1D("h_pT_H", "h_pT_H", 100, 0, 500)));
-    ANA_CHECK (book (TH1D("h_eta_H","h_eta_H", 100, -4.5, 4.5)));
+    ANA_CHECK (book (TH1D("h_eta_H","h_eta_H", 100, -5.5, 5.5)));
     ANA_CHECK (book (TH1D("h_phi_H", "h_phi_H", 100, -4.5, 4.5)));
     //Additional Scalar (S)
     ANA_CHECK (book (TH1D("h_m_S1", "h_m_S1", 100, 0, 200)));
@@ -120,7 +120,7 @@ StatusCode MyxAODAnalysis :: initialize ()
     ANA_CHECK (book (TH1D("h_invMass_4l", "h_invMass_4l", 100, 0, 200)));
     ANA_CHECK (book (TH1D("h_pT_2l_leading", "h_pT_2l_leading", 100, 0, 500)));
     ANA_CHECK (book (TH1D("h_pT_2l_subleading", "h_pT_2l_subleading", 100, 0, 500)));
-    ANA_CHECK (book (TH1D("h_pT_4l", "h_pT_4l", 100, 0, 500)));
+    ANA_CHECK (book (TH1D("h_pT_4l", "h_pT_4l", 100, 0, 1000)));
 
     return StatusCode::SUCCESS;
 }
@@ -209,7 +209,8 @@ StatusCode MyxAODAnalysis :: execute ()
         /*------------------------ SECTION 1 - FIND PARTICLES, GET KINEMATICS ------------------------*/
         const xAOD::TruthParticle* truth = *truth_itr;
         //Initialize bitmask variables
-        bool l1_bool, l3_bool, l5_bool, l7_bool = false;
+        // bool l1_bool, l3_bool, l5_bool, l7_bool = false;
+        bool l1_bool = false, l3_bool = false, l5_bool = false, l7_bool = false;
 
         // Find Higgs and then the rest
         if(truth->pdgId()==25){
@@ -218,10 +219,8 @@ StatusCode MyxAODAnalysis :: execute ()
                 const xAOD::TruthVertex* decayVtx = truth->decayVtx();
                 if ( !(decayVtx -> nOutgoingParticles() == 2)){
                     // ANA_MSG_INFO("Higgs decaying in " << decayVtx->nOutgoingParticles() << " particles");
-
-                    const xAOD::TruthParticle* H_child = decayVtx->outgoingParticle(0);
-                    std::cout << "H_child pdgID: " << H_child->pdgId() << " ___ ";
-
+                    // const xAOD::TruthParticle* H_child = decayVtx->outgoingParticle(0);
+                    // std::cout << "H_child pdgID: " << H_child->pdgId() << " ___ ";
                     continue;
                 }
                 //ANA_MSG_INFO("Higgs found");
@@ -282,10 +281,11 @@ StatusCode MyxAODAnalysis :: execute ()
                                 const xAOD::TruthParticle* childl7 = Zd4_decayVtx->outgoingParticle(0);
                                 const xAOD::TruthParticle* childl8 = Zd4_decayVtx->outgoingParticle(1);
                                 // Print pdgIDs
-                                cout << "[" << childl1->pdgId() << ", " << childl2->pdgId() << "]  ";
-                                cout << "[" << childl3->pdgId() << ", " << childl4->pdgId() << "]  ";
-                                cout << "[" << childl5->pdgId() << ", " << childl6->pdgId() << "]  ";
-                                cout << "[" << childl7->pdgId() << ", " << childl8->pdgId() << "]" << endl;;
+                                cout << "___pdgId's___ " << endl;
+                                // cout << "[" << childl1->pdgId() << ", " << childl2->pdgId() << "]  ";
+                                // cout << "[" << childl3->pdgId() << ", " << childl4->pdgId() << "]  ";
+                                // cout << "[" << childl5->pdgId() << ", " << childl6->pdgId() << "]  ";
+                                // cout << "[" << childl7->pdgId() << ", " << childl8->pdgId() << "]" << endl;
 
                                 /* Visible lepton kinematics
                                 Assumme the following:
@@ -354,13 +354,11 @@ StatusCode MyxAODAnalysis :: execute ()
                                 //Determine leading and subleading pair
                                 pT_2l_Lead = get_lead_sublead_pT(pT_l1l2, pT_l3l4)[0];
                                 pT_2l_Sublead = get_lead_sublead_pT(pT_l1l2, pT_l3l4)[1];
+                                pT_4l = pT_2l_Lead + pT_2l_Sublead;
                                 //4l invariant mass
                                 invM_l1l2 = vec_l1l2.M();
                                 invM_l3l4 = vec_l3l4.M();
                                 invM_4l = (vec_l1l2 + vec_l3l4).M();
-
-                                int bitmask_test = pow(2,3)*l1_bool + pow(2,2)*l3_bool + pow(2,1)*l5_bool + pow(2,0)*l7_bool;
-                                cout << "Bitmask value: " << bitmask_test << endl;
 
                             }//close Zd decay check
                         }//close Zd identity check

--- a/analysis/basic-analysis/event-analysis.h
+++ b/analysis/basic-analysis/event-analysis.h
@@ -28,18 +28,20 @@ public:
     // protected from being send from the submission node to the worker
     // node (done by the //!)
 public:
+    /*
+    Histogram names should follow this format
+    h_ + variable + _ particle type + particle number
+    E.g. h_m_Zd2 for the mass histogram of the 2nd dark vector boson (Zd2)
+    */
+
     //Mass hists //
-    TH1D* h_mH = new TH1D();
-    TH1D* h_mS1 = new TH1D();
-    TH1D* h_mS2 = new TH1D();
-    TH1D* h_mZd1 = new TH1D(); //Zd
-    TH1D* h_mZd2 = new TH1D();
-    TH1D* h_mZd3 = new TH1D();
-    TH1D* h_mZd4 = new TH1D();
-    // TH1D* h_m4l = new TH1D();
-    // TH1D* h_m2l = new TH1D();
-    // TH1D* h_m2l_leading = new TH1D();
-    // TH1D* h_m2l_subleading = new TH1D();
+    TH1D* h_m_H = new TH1D();
+    TH1D* h_m_S1 = new TH1D();
+    TH1D* h_m_S2 = new TH1D();
+    TH1D* h_m_Zd1 = new TH1D(); //Zd
+    TH1D* h_m_Zd2 = new TH1D();
+    TH1D* h_m_Zd3 = new TH1D();
+    TH1D* h_m_Zd4 = new TH1D();
     //pT hists //
     TH1D* h_pT_H = new TH1D();
     TH1D* h_pT_S1 = new TH1D();
@@ -88,10 +90,40 @@ public:
     TH1D* h_phi_u2 = new TH1D();
     TH1D* h_phi_u3 = new TH1D();
     TH1D* h_phi_u4 = new TH1D();
+    //Energy hists //
+    TH1D* h_e_e1 = new TH1D(); //Electrons
+    TH1D* h_e_e2 = new TH1D();
+    TH1D* h_e_e3 = new TH1D();
+    TH1D* h_e_e4 = new TH1D();
+    TH1D* h_e_u1 = new TH1D(); //Muons
+    TH1D* h_e_u2 = new TH1D();
+    TH1D* h_e_u3 = new TH1D();
+    TH1D* h_e_u4 = new TH1D();
+    //Multi lepton hists //
+    TH1D* h_pT_ee12 = new TH1D();
+    TH1D* h_pT_ee34 = new TH1D();
+    TH1D* h_pT_uu12 = new TH1D();
+    TH1D* h_pT_uu34 = new TH1D();
+    //Leading and subleading lepton hists //
+    TH1D* h_pT_ee_lead = new TH1D();
+    TH1D* h_pT_ee_sublead = new TH1D();
+    TH1D* h_pT_uu_lead = new TH1D();
+    TH1D* h_pT_uu_sublead = new TH1D();
+    TH1D* h_pT_lead = new TH1D();
+    TH1D* h_pT_sublead = new TH1D();
     //MET hists //
     TH1* h_missingET;
     TH1* h_missingET_NonInt;
-    
+
+    //Test these
+    // TH1D* h_M_S1 = new TH1D();
+    // TH1D* h_M_Zd1 = new TH1D();
+    // TH1D* h_invMass_l1l2 = new TH1D();
+    // TH1D* h_invMass_l3l4 = new TH1D();
+    // TH1D* h_invMass_4l = new TH1D();
+    // TH1D* h_vectorInvMass_l1l2 = new TH1D();
+    // TH1D* h_vectorInvMass_l3l4 = new TH1D();
+    // TH1D* h_vectorInvMass_4l = new TH1D();
 //    // this is a standard constructor
 //
     virtual StatusCode initialize () override;

--- a/analysis/basic-analysis/event-analysis.h
+++ b/analysis/basic-analysis/event-analysis.h
@@ -91,40 +91,37 @@ public:
     TH1D* h_phi_u3 = new TH1D();
     TH1D* h_phi_u4 = new TH1D();
     //Energy hists //
-    TH1D* h_e_e1 = new TH1D(); //Electrons
-    TH1D* h_e_e2 = new TH1D();
-    TH1D* h_e_e3 = new TH1D();
-    TH1D* h_e_e4 = new TH1D();
-    TH1D* h_e_u1 = new TH1D(); //Muons
-    TH1D* h_e_u2 = new TH1D();
-    TH1D* h_e_u3 = new TH1D();
-    TH1D* h_e_u4 = new TH1D();
+    // TH1D* h_e_e1 = new TH1D(); //Electrons
+    // TH1D* h_e_e2 = new TH1D();
+    // TH1D* h_e_e3 = new TH1D();
+    // TH1D* h_e_e4 = new TH1D();
+    // TH1D* h_e_u1 = new TH1D(); //Muons
+    // TH1D* h_e_u2 = new TH1D();
+    // TH1D* h_e_u3 = new TH1D();
+    // TH1D* h_e_u4 = new TH1D();
     //Multi lepton hists //
-    TH1D* h_pT_ee12 = new TH1D();
-    TH1D* h_pT_ee34 = new TH1D();
-    TH1D* h_pT_uu12 = new TH1D();
-    TH1D* h_pT_uu34 = new TH1D();
+    // TH1D* h_pT_ee12 = new TH1D();
+    // TH1D* h_pT_ee34 = new TH1D();
+    // TH1D* h_pT_uu12 = new TH1D();
+    // TH1D* h_pT_uu34 = new TH1D();
     //Leading and subleading lepton hists //
-    TH1D* h_pT_ee_lead = new TH1D();
-    TH1D* h_pT_ee_sublead = new TH1D();
-    TH1D* h_pT_uu_lead = new TH1D();
-    TH1D* h_pT_uu_sublead = new TH1D();
-    TH1D* h_pT_lead = new TH1D();
-    TH1D* h_pT_sublead = new TH1D();
+    TH1D* h_pT_2l_leading = new TH1D();
+    TH1D* h_pT_2l_subleading = new TH1D();
     //MET hists //
     TH1* h_missingET;
     TH1* h_missingET_NonInt;
 
     //Test these
-    // TH1D* h_M_S1 = new TH1D();
-    // TH1D* h_M_Zd1 = new TH1D();
-    // TH1D* h_invMass_l1l2 = new TH1D();
-    // TH1D* h_invMass_l3l4 = new TH1D();
-    // TH1D* h_invMass_4l = new TH1D();
-    // TH1D* h_vectorInvMass_l1l2 = new TH1D();
-    // TH1D* h_vectorInvMass_l3l4 = new TH1D();
-    // TH1D* h_vectorInvMass_4l = new TH1D();
-//    // this is a standard constructor
+    TH1D* h_invMass_l1l2 = new TH1D();
+    TH1D* h_invMass_l3l4 = new TH1D();
+    TH1D* h_invMass_4l = new TH1D();
+    TH1D* h_pT_4l = new TH1D();
+    // TH1D* h_pT_ee_lead = new TH1D();
+    // TH1D* h_pT_ee_sublead = new TH1D();
+    // TH1D* h_pT_uu_lead = new TH1D();
+    // TH1D* h_pT_uu_sublead = new TH1D();
+
+//    this is a standard constructor
 //
     virtual StatusCode initialize () override;
     virtual StatusCode execute () override;

--- a/analysis/basic-analysis/event-analysis.h
+++ b/analysis/basic-analysis/event-analysis.h
@@ -30,8 +30,10 @@ public:
 public:
     /*
     Histogram names should follow this format
-    h_ + variable + _ particle type + particle number
-    E.g. h_m_Zd2 for the mass histogram of the 2nd dark vector boson (Zd2)
+    h_ {variable}_{particle type}{particle number}_{optional descriptor}
+    Examples:
+    h_m_Zd2 --> mass histogram of the 2nd dark vector boson (Zd2)
+    h_pT_2l_leading --> transverse momentum for leading dilepton (2l)
     */
 
     //Mass hists //
@@ -100,22 +102,23 @@ public:
     // TH1D* h_e_u3 = new TH1D();
     // TH1D* h_e_u4 = new TH1D();
     //Multi lepton hists //
-    // TH1D* h_pT_ee12 = new TH1D();
-    // TH1D* h_pT_ee34 = new TH1D();
-    // TH1D* h_pT_uu12 = new TH1D();
-    // TH1D* h_pT_uu34 = new TH1D();
-    //Leading and subleading lepton hists //
     TH1D* h_pT_2l_leading = new TH1D();
     TH1D* h_pT_2l_subleading = new TH1D();
+    TH1D* h_pT_4l = new TH1D();
+    TH1D* h_invMass_l1l2 = new TH1D();
+    TH1D* h_invMass_l3l4 = new TH1D();
+    TH1D* h_invMass_4l = new TH1D();
     //MET hists //
     TH1* h_missingET;
     TH1* h_missingET_NonInt;
 
-    //Test these
-    TH1D* h_invMass_l1l2 = new TH1D();
-    TH1D* h_invMass_l3l4 = new TH1D();
-    TH1D* h_invMass_4l = new TH1D();
-    TH1D* h_pT_4l = new TH1D();
+    /*  Test these   */
+
+    /*  Possible future histograms   */
+    // TH1D* h_pT_ee12 = new TH1D();
+    // TH1D* h_pT_ee34 = new TH1D();
+    // TH1D* h_pT_uu12 = new TH1D();
+    // TH1D* h_pT_uu34 = new TH1D();
     // TH1D* h_pT_ee_lead = new TH1D();
     // TH1D* h_pT_ee_sublead = new TH1D();
     // TH1D* h_pT_uu_lead = new TH1D();


### PR DESCRIPTION
Updates:

**Multilepton histograms added for:**
- h_invMass_l1l2 --> lepton 1-2 pair
- h_invMass_l3l4 --> lepton 3-4 pair
- h_invMass_4l --> quadruplet
- h_pT_2l_leading --> pT for leading pair
- h_pT_2l_subleading --> pT for subleading pair
- h_pT_4l  --> quadruplet pT

px, py, pz and energy histograms not added - instead PtEtaPhiEVector objects are constructed for each lepton, which can be easily used to calculate subsequent qualities of the pair

**Variables added for**
- Energy for e/u 1-4
- Vectors for e/u 1-4
- Invariant mass for each pair and the quadruplet
- pT for each pair, the quadruplet and leading/ subleading pairs